### PR TITLE
Adicionando a funcionalidade de excluir xom o modal e melhorando a estilização do parágrafo inicial.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,13 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <div id="confirmModal" class="modal">
+        <div class="modal-content">
+            <p>Tem certeza de que deseja excluir esta tarefa?</p>
+            <button id="confirmDelete">Sim</button>
+            <button id="cancelDelete">Cancelar</button>
+        </div>
+    </div>
     <div class="container">
         <h1>To-Do List</h1>
         <p>Bem-vindo à nossa To-Do List! Adicione suas tarefas abaixo:</p>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,13 @@
 document.getElementById('addButton').addEventListener('click', addTask);
 
+// Referência aos elementos do modal
+const modal = document.getElementById("confirmModal");
+const confirmButton = document.getElementById("confirmDelete");
+const cancelButton = document.getElementById("cancelDelete");
+
+let taskToDelete = null;  // Variável para armazenar a tarefa a ser excluída
+
+// Função para adicionar tarefas
 function addTask() {
     const taskInput = document.getElementById('taskInput');
     const taskText = taskInput.value.trim();
@@ -20,9 +28,33 @@ function addTask() {
 
     // Adiciona o evento de exclusão
     li.querySelector('.delete-btn').addEventListener('click', function() {
-        li.remove();
+        taskToDelete = li;  // Armazena a referência da tarefa que será excluída
+        openModal();  // Abre o modal de confirmação
     });
 
     // Limpa o campo de input
     taskInput.value = "";
 }
+
+// Função para abrir o modal de confirmação
+function openModal() {
+    modal.style.display = "block";
+
+    // Confirmar exclusão
+    confirmButton.onclick = function() {
+        taskToDelete.remove();  // Remove a tarefa da lista
+        modal.style.display = "none";  // Fecha o modal
+    };
+
+    // Cancelar exclusão
+    cancelButton.onclick = function() {
+        modal.style.display = "none";  // Apenas fecha o modal sem excluir
+    };
+}
+
+// Função para fechar o modal se clicar fora dele
+window.onclick = function(event) {
+    if (event.target == modal) {
+        modal.style.display = "none";  // Fecha o modal se clicar fora
+    }
+};

--- a/style.css
+++ b/style.css
@@ -14,12 +14,12 @@ body {
     height: 100vh;
 }
 
-.container {
-    background-color: white;
-    border-radius: 10px;
-    padding: 20px;
-    width: 300px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+.container p {
+    text-align: center;
+    margin-bottom: 15px;
+    font-size: 14px;
+    color: #666;
+    line-height: 1.4;
 }
 
 h1 {
@@ -82,4 +82,38 @@ li span {
 
 .delete-btn:hover {
     background-color: #d9534f;
+}
+
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+.modal-content {
+    background-color: white;
+    padding: 20px;
+    margin: 15% auto;
+    width: 30%;
+    border-radius: 10px;
+    text-align: center;
+}
+.modal button {
+    padding: 10px 20px;
+    margin: 10px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+#confirmDelete {
+    background-color: #5cb85c;
+    color: white;
+}
+#cancelDelete {
+    background-color: #d9534f;
+    color: white;
 }


### PR DESCRIPTION
O que foi feito:

- Refatoração da funcionalidade de exclusão de tarefas para adicionar um modal de confirmação.
- O modal é exibido quando o usuário clica no botão de Excluir, pedindo uma confirmação para excluir a tarefa.
- A tarefa só será removida da lista quando o usuário clicar em Sim no modal. Se o usuário clicar em Cancelar, a tarefa não será excluída.
- Adicionada funcionalidade para fechar o modal caso o usuário clique fora dele.
- Refatorado o parágrafo inicial.

Como testar:

- Adicione uma tarefa à lista.
- Clique no botão Excluir de uma tarefa.
- Verifique se o modal de confirmação aparece, perguntando se você tem certeza que deseja excluir.
- Clique em Sim para confirmar e excluir a tarefa, ou em Cancelar para cancelar a exclusão.
- Verifique se o modal fecha corretamente e se o comportamento da tarefa excluída funciona conforme esperado.